### PR TITLE
Add .repo-metadata.json with Semgrep configuration

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Cytracom/cytracom-oss/main/schemas/repo-metadata.schema.json",
+  "semgrep": {
+    "tags": [
+      "mdx",
+      "tier:standard"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.repo-metadata.json` to enable Semgrep tag sync via the [cytracom-oss pipeline](https://github.com/Cytracom/cytracom-oss)
- Tags are auto-detected from the repo's primary language, with `tier:standard` as default

## What this enables

Once merged, the daily [tag sync workflow](https://github.com/Cytracom/cytracom-oss/blob/main/.github/workflows/sync_tags.yaml) will:
1. Discover this file and apply Semgrep project tags (`repo-metadata:true` + any custom tags from `semgrep.tags`)
2. Enable this repo's inclusion in the automated SBOM pipeline

## References

- [Repository Metadata format](https://cytracom.github.io/engineering-docs/reference/repo-metadata/)
- [cytracom-oss pipeline docs](https://github.com/Cytracom/cytracom-oss)
