### PR TITLE
docs(TV-1745): document multi-user assessment sharing

### DIFF
--- a/additional-information/release-notes.mdx
+++ b/additional-information/release-notes.mdx
@@ -3,6 +3,12 @@ title: "Release Notes"
 description: "Get Notified of New Features"
 ---
 
+<Update label="05-14-2026" description="One Item">
+  **Share Assessments With Teammates**
+
+  You can now share a single assessment with additional teammates without giving them access to every assessment in your account. Open the assessment, click **Manage Access**, and add the users you want to collaborate with. Shared users see the assessment in their dashboard with full edit access, receive the same hourly alert emails, and lose access cleanly when you remove them (with a retained audit record). See `/getting-started/set-up-telivy-account/overview` → "Sharing Assessments With Teammates" for the full breakdown of who can share, what shared users can do, and how sharing differs from reassigning ownership.
+</Update>
+
 <Update label="09-09-2025" description="One Item">
   **Mac OS Scanner Upgrades**
 

--- a/additional-information/release-notes.mdx
+++ b/additional-information/release-notes.mdx
@@ -3,12 +3,6 @@ title: "Release Notes"
 description: "Get Notified of New Features"
 ---
 
-<Update label="05-14-2026" description="One Item">
-  **Share Assessments With Teammates**
-
-  You can now share a single assessment with additional teammates without giving them access to every assessment in your account. Open the assessment, click **Manage Access**, and add the users you want to collaborate with. Shared users see the assessment in their dashboard with full edit access, receive the same hourly alert emails, and lose access cleanly when you remove them (with a retained audit record). See `/getting-started/set-up-telivy-account/overview` → "Sharing Assessments With Teammates" for the full breakdown of who can share, what shared users can do, and how sharing differs from reassigning ownership.
-</Update>
-
 <Update label="09-09-2025" description="One Item">
   **Mac OS Scanner Upgrades**
 

--- a/frequently-asked-questions/telivy-accounts-and-platforms.mdx
+++ b/frequently-asked-questions/telivy-accounts-and-platforms.mdx
@@ -15,5 +15,13 @@ description: 'Common questions and answers'
     <Accordion title="How Do I Manage My Telivy Account Settings">
         Please refer to [this](/getting-started/set-up-telivy-account/overview.mdx) article for more details on Account settings.
     </Accordion>
+
+    <Accordion title="Can Multiple Users See The Same Assessment?">
+        Yes. Each assessment has one **owner** (the user who created it, or whoever it was reassigned to) and can have additional **shared users**. Shared users see the assessment in their dashboard with full edit access — they can rescan, view reports, archive, convert, and receive the same alert emails.
+
+        Sharing is managed from the assessment detail page via **Manage Access**, and can be done by the owner, any Account Admin in the same account, or a Telivy Admin. Sharing does not change anyone's account-level role in Unity — a Telivy User who is shared on one assessment does not gain access to any other assessment.
+
+        For a side-by-side comparison of **sharing** vs **reassigning**, see [Overview → Sharing Assessments With Teammates](/getting-started/set-up-telivy-account/overview.mdx).
+    </Accordion>
 </AccordionGroup>
 

--- a/getting-started/set-up-telivy-account/overview.mdx
+++ b/getting-started/set-up-telivy-account/overview.mdx
@@ -26,8 +26,8 @@ Note: Currently Account tab is only visible to account admins.
   <Accordion title="Access Control Made Simple">
     View a list of your organization's users and their permission levels. Two options are available:
 
-    - **All Assessments**: Users can access every assessment conducted within your organization. This will make them an "Agency Admin"
-    - **Own Assessments**: Users can only access assessments they personally created.
+    - **All Assessments**: Users can access every assessment conducted within your organization. This will make them an "Account Admin"
+    - **Own Assessments (+ Shared)**: Users can access assessments they personally created **and** any assessments that have been explicitly shared with them by an admin or the original creator. See "Sharing Assessments With Teammates" below for details.
 
     ![](/images/access-control-made-simple.jpg)
   </Accordion>
@@ -36,8 +36,29 @@ Note: Currently Account tab is only visible to account admins.
 
     ![](/images/expand-your-team.png)
   </Accordion>
+  <Accordion title="Sharing Assessments With Teammates">
+    Need a teammate to help on a specific assessment without granting them access to every assessment in your agency? Open the assessment and use **Manage Access** to add additional users.
+
+    **Who can manage access?**
+    - The assessment **owner** (the user who originally created it, or whoever the assessment was reassigned to)
+    - **Account Admins** in the same account
+    - **Telivy Admins**
+
+    **What shared users can do:** Shared users have the same edit and view permissions as the owner on that single assessment — they can rescan, view reports, archive, convert, and receive the same hourly alert emails. They cannot, however, add or remove other shared users, or transfer ownership.
+
+    **What shared users cannot do:** Manage the sharing list, reassign the assessment to someone else, or see other assessments they were not added to.
+
+    **Removing access:** Removing a shared user is non-destructive. The assessment retains an audit record (who was shared, who removed them, when), even though the user immediately loses access.
+
+    **Note on Unity:** Your Unity role (Telivy User / Telivy Admin) still controls whether you're an Account Admin in Telivy. Sharing a single assessment with a Telivy User does **not** change their Unity role or give them access to any other assessment.
+  </Accordion>
   <Accordion title="Reassigning / Archiving Assessments">
-    Bulk re-assign assessments using the check boxes in the Telivy dashboard. Or you can archived those assessments
+    Reassigning is different from sharing:
+
+    - **Reassign** transfers full ownership of an assessment from one user to another. The previous owner loses access (unless they were also added as a shared user). Use this when a team member leaves or hands off a client permanently.
+    - **Share** adds a teammate to an assessment without removing anyone. Use this for short-term collaboration or backup coverage.
+
+    Bulk re-assign assessments using the check boxes in the Telivy dashboard. Or you can archive those assessments.
 
     ![](/images/reassigning-archiving-assessments.png)
   </Accordion>


### PR DESCRIPTION
## Jira

[TV-1745](https://cytracom.atlassian.net/browse/TV-1745)

Pairs with:
- Backend: https://github.com/Cytracom/telivy-backend/pull/2846
- Frontend: https://github.com/Cytracom/telivy-frontend/pull/2077

## Summary

Documents the new multi-user assessment sharing model from the MSP
perspective. Each assessment now has a single **owner** (existing
behavior, unchanged) plus optional **shared users** who get full
edit/view access on that one assessment without becoming Account Admins.

## Changes

- `getting-started/set-up-telivy-account/overview.mdx`
  - New accordion **"Sharing Assessments With Teammates"** under
    *Users: Manage Your Team*. Covers who can share, what shared
    users can do, what they can't, audit retention on removal, and
    the Unity caveat (sharing one assessment does not change anyone's
    Unity role).
  - Tightened **"Reassigning / Archiving Assessments"** to contrast
    *reassign* (ownership transfer, previous owner loses access) vs
    *share* (additive, nobody loses access). Same paragraph existed
    before but didn't make the distinction explicit.
  - Updated **"Own Assessments"** description to mention the new
    `+ Shared` behavior.
- `frequently-asked-questions/telivy-accounts-and-platforms.mdx`
  - New FAQ accordion **"Can Multiple Users See The Same Assessment?"**
    with a cross-link to the Overview deep-dive.

### Voice / terminology decision

The FE PR renames the role label **"Agency Admin" -> "Account Admin"**
in the UI (chip + help text). To keep the docs aligned with what
customers will actually see, I applied the same rename **only** to the
two pages this PR touches. The broader docs rename across all 47 pages
is intentionally out of scope here — let me know if you want a
follow-up audit PR for that.

## Pre-publish checklist

- [x] All touched pages still have `title:` + meaningful `description:` frontmatter
- [x] No new pages added, so `docs.json` does not need changes
- [x] No empty `href=""` introduced
- [x] No external links to Google Docs / Confluence / Notion in new content
- [x] FAQ uses `<Accordion>` (not numbered lists); overview deep-dive uses bullets (not Accordion-as-steps)
- [x] MSP voice throughout — no "robust", no "cutting-edge", no end-user voice

## Test plan

- [ ] `mintlify dev` locally renders both touched pages without errors
- [ ] The cross-link from the FAQ to the Overview accordion resolves
- [ ] Visual review of the new Accordion bodies in dark + light mode

[TV-1745]: https://cytracom.atlassian.net/browse/TV-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ