### PR TITLE
docs: document CVE data sources, PII evidence handling, and Mask PII control

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -44,7 +44,8 @@
               "learning-center/dark-web-scans",
               "learning-center/typo-squatting",
               "learning-center/open-ports",
-              "learning-center/ssl-tls-misconfigurations"
+              "learning-center/ssl-tls-misconfigurations",
+              "learning-center/vulnerability-data-sources"
             ]
           },
           {
@@ -75,6 +76,7 @@
                   "products/risk-assessments/whitelist-telivy-with-av-edr",
                   "products/risk-assessments/install-telivy-agent-windows",
                   "products/risk-assessments/identity-and-access-management",
+                  "products/risk-assessments/data-security",
                   "products/risk-assessments/microsoft-365-security",
                   "products/risk-assessments/google-workspace-security",
                   "products/risk-assessments/auto-update",

--- a/frequently-asked-questions/risk-assessments-and-external-scans.mdx
+++ b/frequently-asked-questions/risk-assessments-and-external-scans.mdx
@@ -122,7 +122,7 @@ description: "Common questions and answers"
   <Accordion title="What CVE Database Does Telivy Use?">
     Telivy combines three sources to make vulnerability findings both complete and actually prioritizable:
 
-    * **The CVE Program (cvelistV5)** — the authoritative CVE catalog published by the CNAs through MITRE — is synced nightly into Telivy's vulnerability database. This is the same upstream source NVD ingests from, so Telivy's coverage tracks new and updated CVEs within 24 hours of upstream publication.
+    * **The CVE Program (cvelistV5)**, the authoritative CVE catalog published by the CNAs through MITRE, is synced nightly into Telivy's vulnerability database. This is the same upstream source NVD ingests from, so Telivy's coverage tracks new and updated CVEs within 24 hours of upstream publication.
 
     * **Vulners** (executed via the Nmap `vulners` script) handles scan-time correlation. When the network or agent scanner fingerprints a service or installed software version, Vulners maps that fingerprint to the CVEs that affect it, including signal about whether public exploits exist.
 
@@ -134,13 +134,13 @@ description: "Common questions and answers"
   <Accordion title="Does Telivy Store The Actual PII It Finds (Like Credit Card Numbers)?">
     By default, yes. When the Telivy agent's Data Security scan finds a PII match on an endpoint, the platform captures the matched value along with file path, device, PII type, and a dollar-risk valuation. Transmission from the agent to the platform is encrypted at the application layer, and access inside the platform is gated by `ApplicationAccess` controls. The reason the default captures the value is operational: confirming a finding isn't a false positive (a Luhn-valid string in a code sample, an old test export) requires being able to see what was matched.
 
-    Cleartext **passwords** from the password-analysis module are handled differently — they are never transmitted off the device; only hashes are stored. PII matches are governed by a separate control described in the next FAQ entry.
+    Cleartext **passwords** from the password-analysis module are handled differently: they are never transmitted off the device; only hashes are stored. PII matches are governed by a separate control described in the next FAQ entry.
 
     For full detail, including how matches appear in the platform and what's covered in exports, see [Data Security](/products/risk-assessments/data-security).
   </Accordion>
 
   <Accordion title="Can I Prevent PII Evidence From Being Shown In The Platform?">
-    Yes. Telivy provides a **Mask PII Data (may be required under HIPAA)** setting at the agency level and per-assessment, located in **Account Settings → PII Configuration → Configure PII Costs**. When enabled, the platform redacts the literal match values everywhere they would otherwise appear — the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. Counts, file paths, device names, and dollar-risk valuations are still shown, so the finding remains actionable.
+    Yes. Telivy provides a **Mask PII Data (may be required under HIPAA)** setting at the agency level and per-assessment, located in **Account Settings → PII Configuration → Configure PII Costs**. When enabled, the platform redacts the literal match values everywhere they would otherwise appear: the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. Counts, file paths, device names, and dollar-risk valuations are still shown, so the finding remains actionable.
 
     **Important:** the setting requires a rescan to take effect on already-captured findings. After enabling Mask PII Data, run **Rescan All** on the affected assessments to refresh the data. New scans honor the masking from the moment of capture.
 

--- a/frequently-asked-questions/risk-assessments-and-external-scans.mdx
+++ b/frequently-asked-questions/risk-assessments-and-external-scans.mdx
@@ -118,4 +118,32 @@ description: "Common questions and answers"
 
       * Browser history and passwords captured only for the local user
   </Accordion>
+
+  <Accordion title="What CVE Database Does Telivy Use?">
+    Telivy combines three sources to make vulnerability findings both complete and actually prioritizable:
+
+    * **The CVE Program (cvelistV5)** — the authoritative CVE catalog published by the CNAs through MITRE — is synced nightly into Telivy's vulnerability database. This is the same upstream source NVD ingests from, so Telivy's coverage tracks new and updated CVEs within 24 hours of upstream publication.
+
+    * **Vulners** (executed via the Nmap `vulners` script) handles scan-time correlation. When the network or agent scanner fingerprints a service or installed software version, Vulners maps that fingerprint to the CVEs that affect it, including signal about whether public exploits exist.
+
+    * **EPSS (Exploit Prediction Scoring System)** is pulled daily and stored per CVE. EPSS scores represent the probability of a CVE being exploited in the next 30 days and drive Telivy's prioritization, so partners can sort by what's likely to be hit instead of by CVSS alone.
+
+    NVD is used for the human-readable detail link on each finding (`nvd.nist.gov/vuln/detail/CVE-...`), not as the bulk feed Telivy ingests from. For a deeper walkthrough you can hand to a client or auditor, see [Vulnerability Data Sources](/learning-center/vulnerability-data-sources).
+  </Accordion>
+
+  <Accordion title="Does Telivy Store The Actual PII It Finds (Like Credit Card Numbers)?">
+    By default, yes. When the Telivy agent's Data Security scan finds a PII match on an endpoint, the platform captures the matched value along with file path, device, PII type, and a dollar-risk valuation. Transmission from the agent to the platform is encrypted at the application layer, and access inside the platform is gated by `ApplicationAccess` controls. The reason the default captures the value is operational: confirming a finding isn't a false positive (a Luhn-valid string in a code sample, an old test export) requires being able to see what was matched.
+
+    Cleartext **passwords** from the password-analysis module are handled differently — they are never transmitted off the device; only hashes are stored. PII matches are governed by a separate control described in the next FAQ entry.
+
+    For full detail, including how matches appear in the platform and what's covered in exports, see [Data Security](/products/risk-assessments/data-security).
+  </Accordion>
+
+  <Accordion title="Can I Prevent PII Evidence From Being Shown In The Platform?">
+    Yes. Telivy provides a **Mask PII Data (may be required under HIPAA)** setting at the agency level and per-assessment, located in **Account Settings → PII Configuration → Configure PII Costs**. When enabled, the platform redacts the literal match values everywhere they would otherwise appear — the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. Counts, file paths, device names, and dollar-risk valuations are still shown, so the finding remains actionable.
+
+    **Important:** the setting requires a rescan to take effect on already-captured findings. After enabling Mask PII Data, run **Rescan All** on the affected assessments to refresh the data. New scans honor the masking from the moment of capture.
+
+    A separate **Mask Dark Web Passwords** toggle on the same screen controls how dark-web credential evidence is displayed. The two toggles are independent. See [Data Security](/products/risk-assessments/data-security#mask-pii-data-the-supported-privacy-control) for the full configuration walkthrough.
+  </Accordion>
 </AccordionGroup>

--- a/learning-center/vulnerability-data-sources.mdx
+++ b/learning-center/vulnerability-data-sources.mdx
@@ -9,13 +9,13 @@ When a Telivy assessment lands a long list of CVEs in front of a client, the fir
 
 ## What this is
 
-Telivy doesn't rely on a single CVE feed. The platform combines an **authoritative vulnerability catalog**, **scan-time correlation against what's actually running in your client's environment**, and an **exploit-likelihood signal** so findings reflect real-world risk — not just whatever has the highest CVSS score on paper.
+Telivy doesn't rely on a single CVE feed. The platform combines an **authoritative vulnerability catalog**, **scan-time correlation against what's actually running in your client's environment**, and an **exploit-likelihood signal** so findings reflect real-world risk, not just whatever has the highest CVSS score on paper.
 
 Three data sources back every CVE you see in a Telivy report:
 
 | Source | What it provides | Where it lives |
 | --- | --- | --- |
-| **CVE Program (cvelistV5)** | The authoritative CVE catalog — every CVE ID, description, affected products, references | Telivy's vulnerability database |
+| **CVE Program (cvelistV5)** | The authoritative CVE catalog: every CVE ID, description, affected products, references | Telivy's vulnerability database |
 | **Vulners (via Nmap)** | Maps a fingerprinted service or software version to the CVEs that affect it | Scan-time correlation |
 | **EPSS** | A daily-refreshed score predicting how likely each CVE is to be exploited in the next 30 days | Per-CVE prioritization signal |
 
@@ -39,7 +39,7 @@ When a partner asks, frame it like this: *"Our platform pulls from the same auth
 
 ### 1. The authoritative catalog: CVE Program (cvelistV5)
 
-Telivy syncs the **official CVE Program 5.0 JSON feed** — published by the CVE Numbering Authorities through MITRE — into its own vulnerability database. This is the same upstream source NVD ingests from.
+Telivy syncs the **official CVE Program 5.0 JSON feed**, published by the CVE Numbering Authorities through MITRE, into its own vulnerability database. This is the same upstream source NVD ingests from.
 
 The sync runs nightly. Every published CVE includes:
 
@@ -55,7 +55,7 @@ The sync runs nightly. Every published CVE includes:
 
 Knowing what CVEs *exist* is half the job. Knowing which ones apply to *your client's environment* is the other half.
 
-When Telivy's network or agent scanner identifies a running service or installed software — say, OpenSSH 7.2p2 on a Linux box, or an outdated version of Apache on an internal web server — that fingerprint is matched against the **Vulners** correlation database (executed via the Nmap `vulners` script). Vulners maps the specific software/version to the CVEs that affect it, and includes signal about whether public exploits exist (Metasploit modules, ExploitDB entries, etc.).
+When Telivy's network or agent scanner identifies a running service or installed software (say, OpenSSH 7.2p2 on a Linux box, or an outdated version of Apache on an internal web server), that fingerprint is matched against the **Vulners** correlation database (executed via the Nmap `vulners` script). Vulners maps the specific software/version to the CVEs that affect it, and includes signal about whether public exploits exist (Metasploit modules, ExploitDB entries, etc.).
 
 **What this means in practice:** you don't get a list of every CVE that could possibly affect any vendor. You get the list of CVEs that affect the *exact* software your scanner found running.
 
@@ -69,17 +69,17 @@ EPSS scores feed into Telivy's prioritization so your tech can sort findings by 
 
 ### 4. Reference linking: NVD
 
-When a partner clicks into a finding, Telivy links the CVE detail page on **NVD** (`nvd.nist.gov/vuln/detail/CVE-...`). NVD is used here as a **reference and citation source** for human readers — not as the bulk data feed Telivy ingests from.
+When a partner clicks into a finding, Telivy links the CVE detail page on **NVD** (`nvd.nist.gov/vuln/detail/CVE-...`). NVD is used here as a **reference and citation source** for human readers, not as the bulk data feed Telivy ingests from.
 
 ---
 
-## How MSPs use this in practice — Analyze → Prioritize → Commit
+## How MSPs use this in practice: Analyze → Prioritize → Commit
 
-**Analyze.** Open the vulnerabilities view for the assessment. The full list is the *catalog hits* — every CVE that maps to something running in the environment. Don't try to remediate the whole list.
+**Analyze.** Open the vulnerabilities view for the assessment. The full list is the *catalog hits*: every CVE that maps to something running in the environment. Don't try to remediate the whole list.
 
-**Prioritize.** Sort by EPSS score, not raw CVSS. Filter to CVEs above the EPSS percentile threshold your client's risk appetite supports (a common cutoff is the top 10% of likely-to-be-exploited CVEs). Pair that with affected-asset count — a high-EPSS CVE on 40 endpoints is a different conversation than the same CVE on a single decommissioned VM.
+**Prioritize.** Sort by EPSS score, not raw CVSS. Filter to CVEs above the EPSS percentile threshold your client's risk appetite supports (a common cutoff is the top 10% of likely-to-be-exploited CVEs). Pair that with affected-asset count: a high-EPSS CVE on 40 endpoints is a different conversation than the same CVE on a single decommissioned VM.
 
-**Commit.** Push remediation through your standard patch workflow. When the next scan runs, Telivy correlates again against the upstream catalog, and remediated findings close automatically — no manual reconciliation.
+**Commit.** Push remediation through your standard patch workflow. When the next scan runs, Telivy correlates again against the upstream catalog, and remediated findings close automatically, with no manual reconciliation needed.
 
 ---
 
@@ -91,7 +91,7 @@ A 60-employee professional services firm runs its first Telivy Risk Assessment a
 - **47 hits with EPSS > 0.5** (CVEs the model predicts have at least a 50% chance of being exploited in the next 30 days)
 - **9 hits with EPSS > 0.9** concentrated on three machines: an unpatched developer laptop, a forgotten file server, and a printer running a 4-year-old firmware
 
-The MSP doesn't quote a 3,200-finding remediation project. They show the SMB owner a one-page summary: *"You have nine vulnerabilities that, statistically, are very likely to be hit in the next month — and they all live on three machines. We can clear them this week."* That's the conversation that gets approved. The other 3,191 findings move into a defined patching cadence and stop being a wall of red text in the QBR deck.
+The MSP doesn't quote a 3,200-finding remediation project. They show the SMB owner a one-page summary: *"You have nine vulnerabilities that, statistically, are very likely to be hit in the next month, and they all live on three machines. We can clear them this week."* That's the conversation that gets approved. The other 3,191 findings move into a defined patching cadence and stop being a wall of red text in the QBR deck.
 
 ---
 
@@ -107,13 +107,13 @@ The MSP doesn't quote a 3,200-finding remediation project. They show the SMB own
 ## Common misunderstandings
 
 **"Telivy uses the NVD API."**
-Not as the bulk feed. Telivy ingests the upstream **CVE Program (cvelistV5)** JSON — which is the same source NVD ingests from. NVD is used for the human-readable detail link on each finding. The practical difference: Telivy's data is not gated by NVD's enrichment pipeline, so newly-published CVEs appear in Telivy on the next nightly sync regardless of NVD's enrichment status.
+Not as the bulk feed. Telivy ingests the upstream **CVE Program (cvelistV5)** JSON, which is the same source NVD ingests from. NVD is used for the human-readable detail link on each finding. The practical difference: Telivy's data is not gated by NVD's enrichment pipeline, so newly-published CVEs appear in Telivy on the next nightly sync regardless of NVD's enrichment status.
 
 **"Higher CVSS = higher priority."**
-CVSS describes the *worst case if exploited*. EPSS describes the *likelihood of exploitation*. A CVE can be CVSS 9.8 and EPSS 0.001 — terrifying in theory, virtually never seen in the wild. Use both signals; lead with EPSS for prioritization.
+CVSS describes the *worst case if exploited*. EPSS describes the *likelihood of exploitation*. A CVE can be CVSS 9.8 and EPSS 0.001. Terrifying in theory, virtually never seen in the wild. Use both signals; lead with EPSS for prioritization.
 
 **"If a CVE isn't in Telivy, my client isn't affected."**
-Coverage tracks the CVE Program upstream. If a CVE is published but the affected product isn't running on a system Telivy scans, you won't see a finding — by design. If you suspect a missed correlation (e.g., a known-vulnerable service that didn't generate a finding), check whether the asset was reachable during the scan window and whether the agent fingerprinted the service version correctly.
+Coverage tracks the CVE Program upstream. If a CVE is published but the affected product isn't running on a system Telivy scans, you won't see a finding, by design. If you suspect a missed correlation (e.g., a known-vulnerable service that didn't generate a finding), check whether the asset was reachable during the scan window and whether the agent fingerprinted the service version correctly.
 
 ---
 

--- a/learning-center/vulnerability-data-sources.mdx
+++ b/learning-center/vulnerability-data-sources.mdx
@@ -1,0 +1,122 @@
+---
+title: "Vulnerability Data Sources"
+description: "Where the CVEs in your client's findings come from, how Telivy decides which ones actually matter, and what to tell a partner who asks."
+---
+
+When a Telivy assessment lands a long list of CVEs in front of a client, the first question a careful MSP will get back is: *"where is that data coming from, and why should I trust the prioritization?"* This page is the answer you can hand to a partner, a CIO doing vendor due diligence, or your own tech who wants to know what's behind the dashboard.
+
+---
+
+## What this is
+
+Telivy doesn't rely on a single CVE feed. The platform combines an **authoritative vulnerability catalog**, **scan-time correlation against what's actually running in your client's environment**, and an **exploit-likelihood signal** so findings reflect real-world risk — not just whatever has the highest CVSS score on paper.
+
+Three data sources back every CVE you see in a Telivy report:
+
+| Source | What it provides | Where it lives |
+| --- | --- | --- |
+| **CVE Program (cvelistV5)** | The authoritative CVE catalog — every CVE ID, description, affected products, references | Telivy's vulnerability database |
+| **Vulners (via Nmap)** | Maps a fingerprinted service or software version to the CVEs that affect it | Scan-time correlation |
+| **EPSS** | A daily-refreshed score predicting how likely each CVE is to be exploited in the next 30 days | Per-CVE prioritization signal |
+
+Plus, for context, finding details link out to **NVD** (`nvd.nist.gov`) so a partner or auditor can read the public write-up without leaving a citation trail through Telivy.
+
+---
+
+## Why it matters to MSPs
+
+A weak vulnerability data set produces three predictable failures, and your client will notice all of them:
+
+- **Stale or partial CVE data → missed findings.** If the catalog is days behind or only covers a vendor subset, a recently-disclosed exploit won't appear in the scan, and your tech walks into the QBR claiming a clean room that isn't.
+- **CVSS-only ranking → wasted Tuesdays.** A client environment of 200 endpoints can easily show 4,000+ open CVEs after a deep scan. Without an exploitability signal, your tech ends up patching 9.8s that nobody is exploiting and missing 7.2s that are actively being weaponized.
+- **No traceable source → losing the trust conversation.** "Telivy says it's a problem" is not a defensible answer when a CIO asks where the finding came from. *"It's a CVE Program record, correlated to your running version of OpenSSH, with an EPSS score in the top 1% of likely-to-be-exploited CVEs"* is.
+
+When a partner asks, frame it like this: *"Our platform pulls from the same authoritative feeds NVD itself ingests from, then layers an exploit-likelihood model so we tell you what to fix this week, not what to argue about next quarter."*
+
+---
+
+## How it works
+
+### 1. The authoritative catalog: CVE Program (cvelistV5)
+
+Telivy syncs the **official CVE Program 5.0 JSON feed** — published by the CVE Numbering Authorities through MITRE — into its own vulnerability database. This is the same upstream source NVD ingests from.
+
+The sync runs nightly. Every published CVE includes:
+
+- The CVE ID and description
+- Affected products and versions (CPE-style identifiers)
+- CVSS v2 and v3 metrics
+- Public references (vendor advisories, exploit databases, write-ups)
+- Publication and last-modified timestamps
+
+**What this means in practice:** when a CVE is published or updated by its CNA, it's reflected in Telivy on the next nightly sync. Your client's findings track upstream CVE Program changes within 24 hours.
+
+### 2. Scan-time correlation: Vulners
+
+Knowing what CVEs *exist* is half the job. Knowing which ones apply to *your client's environment* is the other half.
+
+When Telivy's network or agent scanner identifies a running service or installed software — say, OpenSSH 7.2p2 on a Linux box, or an outdated version of Apache on an internal web server — that fingerprint is matched against the **Vulners** correlation database (executed via the Nmap `vulners` script). Vulners maps the specific software/version to the CVEs that affect it, and includes signal about whether public exploits exist (Metasploit modules, ExploitDB entries, etc.).
+
+**What this means in practice:** you don't get a list of every CVE that could possibly affect any vendor. You get the list of CVEs that affect the *exact* software your scanner found running.
+
+### 3. Exploit prioritization: EPSS
+
+Once Telivy knows which CVEs apply, the next question is: *which of these is actually being exploited in the wild?*
+
+**EPSS (Exploit Prediction Scoring System)** is a daily-refreshed model that scores every CVE on a 0–1 scale representing the probability the CVE will be exploited in the next 30 days. Telivy pulls the EPSS dataset on a daily schedule and stores the score per CVE.
+
+EPSS scores feed into Telivy's prioritization so your tech can sort findings by what's *likely to be hit*, not just by CVSS severity. A CVSS 9.8 with an EPSS of 0.001 is a very different problem than a CVSS 7.5 with an EPSS of 0.94.
+
+### 4. Reference linking: NVD
+
+When a partner clicks into a finding, Telivy links the CVE detail page on **NVD** (`nvd.nist.gov/vuln/detail/CVE-...`). NVD is used here as a **reference and citation source** for human readers — not as the bulk data feed Telivy ingests from.
+
+---
+
+## How MSPs use this in practice — Analyze → Prioritize → Commit
+
+**Analyze.** Open the vulnerabilities view for the assessment. The full list is the *catalog hits* — every CVE that maps to something running in the environment. Don't try to remediate the whole list.
+
+**Prioritize.** Sort by EPSS score, not raw CVSS. Filter to CVEs above the EPSS percentile threshold your client's risk appetite supports (a common cutoff is the top 10% of likely-to-be-exploited CVEs). Pair that with affected-asset count — a high-EPSS CVE on 40 endpoints is a different conversation than the same CVE on a single decommissioned VM.
+
+**Commit.** Push remediation through your standard patch workflow. When the next scan runs, Telivy correlates again against the upstream catalog, and remediated findings close automatically — no manual reconciliation.
+
+---
+
+## Example scenario
+
+A 60-employee professional services firm runs its first Telivy Risk Assessment as part of their MSP's onboarding. The deep scan returns:
+
+- **3,200 catalog hits** across 78 endpoints (every CVE that maps to running software)
+- **47 hits with EPSS > 0.5** (CVEs the model predicts have at least a 50% chance of being exploited in the next 30 days)
+- **9 hits with EPSS > 0.9** concentrated on three machines: an unpatched developer laptop, a forgotten file server, and a printer running a 4-year-old firmware
+
+The MSP doesn't quote a 3,200-finding remediation project. They show the SMB owner a one-page summary: *"You have nine vulnerabilities that, statistically, are very likely to be hit in the next month — and they all live on three machines. We can clear them this week."* That's the conversation that gets approved. The other 3,191 findings move into a defined patching cadence and stop being a wall of red text in the QBR deck.
+
+---
+
+## Key value delivered
+
+- **Revenue:** A defensible prioritization story makes ongoing patch management an obvious recurring service line, not a one-time project.
+- **Risk reduction:** Patching the EPSS top-decile shrinks the realistic attack surface far more than chasing CVSS for its own sake.
+- **Client communication:** "Our prioritization is based on the same exploit-prediction model the federal government and major insurers use." That sentence ends a lot of debates.
+- **Operational efficiency:** Your tech doesn't burn a day on CVEs nobody is exploiting.
+
+---
+
+## Common misunderstandings
+
+**"Telivy uses the NVD API."**
+Not as the bulk feed. Telivy ingests the upstream **CVE Program (cvelistV5)** JSON — which is the same source NVD ingests from. NVD is used for the human-readable detail link on each finding. The practical difference: Telivy's data is not gated by NVD's enrichment pipeline, so newly-published CVEs appear in Telivy on the next nightly sync regardless of NVD's enrichment status.
+
+**"Higher CVSS = higher priority."**
+CVSS describes the *worst case if exploited*. EPSS describes the *likelihood of exploitation*. A CVE can be CVSS 9.8 and EPSS 0.001 — terrifying in theory, virtually never seen in the wild. Use both signals; lead with EPSS for prioritization.
+
+**"If a CVE isn't in Telivy, my client isn't affected."**
+Coverage tracks the CVE Program upstream. If a CVE is published but the affected product isn't running on a system Telivy scans, you won't see a finding — by design. If you suspect a missed correlation (e.g., a known-vulnerable service that didn't generate a finding), check whether the asset was reachable during the scan window and whether the agent fingerprinted the service version correctly.
+
+---
+
+## Quick summary
+
+Telivy combines the authoritative CVE Program catalog, scan-time Vulners correlation against your client's actual running software, and the EPSS exploit-prediction model to produce a vulnerability list that's both complete and actually prioritizable. Lead client conversations with EPSS-driven priority, not CVSS counts, and your remediation work will be the conversation that gets funded.

--- a/products/risk-assessments/data-security.mdx
+++ b/products/risk-assessments/data-security.mdx
@@ -1,0 +1,166 @@
+---
+title: "Data Security"
+description: "How Telivy detects PII on a client's endpoints, what evidence the platform stores and displays, and how to control it for HIPAA-sensitive partners."
+---
+
+Data Security is the part of a Telivy Risk Assessment that finds personally identifiable information sitting on the wrong machines, in the wrong folders — and quantifies what it would cost the client if any of those machines got lost, stolen, or compromised. This page explains exactly what Telivy scans, what evidence is captured, what shows up in the platform, and how to configure it for partners with stricter privacy or HIPAA requirements.
+
+---
+
+## Overview
+
+The Telivy agent inspects files on each endpoint during its scan and identifies content that matches recognized PII patterns: credit card numbers, Social Security numbers (and Canadian SIN equivalents), email addresses, phone numbers, and other regulated identifiers. For each match, Telivy captures the **file path**, the **device**, the **PII type**, the **match count**, and a **dollar-risk valuation** based on per-record liability assumptions. Findings roll up into a per-device and per-client view your tech can act on — and that an MSP can put in front of an SMB owner during a QBR or insurance renewal.
+
+The output is the conversation that gets cyber insurance approved: *"Your client has 14,000 records of regulated PII spread across 22 laptops, and three of those laptops are unencrypted. That's the carrier's first question."*
+
+---
+
+## Requirements
+
+- A **Risk Assessment** (Data Security is included). External Assessments do not perform PII detection.
+- The **Telivy agent** deployed on the endpoints to be scanned. Agentless mode is supported with a meaningful limitation:
+  - **Agent (recommended):** Scans files accessible to the system; broadest coverage.
+  - **Agentless:** Runs in the security context of the local user. Only files readable by that user are scanned.
+- For **OneDrive PII** detection, the assessment must have OneDrive scanning enabled at the machine level.
+
+---
+
+## What Telivy scans for
+
+Telivy classifies findings by PII type. The most common categories:
+
+| Category | Examples |
+| --- | --- |
+| **Credit card** | 14–19 digit card numbers passing Luhn validation |
+| **Social Security Number** | US SSNs, Canadian SIN equivalents (Luhn-validated) |
+| **Personal contact data** | Email addresses, phone numbers |
+| **Other regulated identifiers** | Drivers license, passport, tax ID patterns by region |
+
+Each finding is enriched with a **dollar-risk valuation** — a per-record liability estimate that lets the platform roll up "this client has \$1.2M of exposure on this one fileserver" rather than just "this client has 14,000 records." You can adjust the per-record weights in the **Configure PII Costs** modal (covered below).
+
+---
+
+## How matches appear in the platform
+
+The Data Risk experience has two views, deliberately separated:
+
+1. **The grid view** (Data Risk modal). Columns include device, file path, file size, last modified, PII type, **match count**, and dollar-risk. The actual matched values are **not** shown in the grid — only the count.
+2. **The detail view** (per-file modal, opened with **View**). Shows full file metadata plus a **Data Found** section that displays the matched values themselves (for example, the literal numbers a credit-card pattern matched on). This is the screen your tech uses to confirm a finding isn't a false positive — a Luhn-valid string in a code sample, an old testing export, a year-end CSV that should have been purged.
+
+**Reports and exports.** The CSV PII report includes columns by category (Credit Card Matches, SSN/ID Matches, Email Matches, etc.) and is intended for the same operational use as the detail view: confirming materiality and routing remediation.
+
+---
+
+## Privacy & custody — what leaves the device
+
+This is the section to read carefully if your partner is HIPAA-sensitive, has a strict vendor risk program, or has asked the question directly.
+
+**By default**, Telivy is designed to give the MSP enough evidence to confirm that a finding is real and to drive remediation. That includes capturing **a sample of the matched value** along with file path, device, and PII type. The data flow is:
+
+1. The Telivy agent scans files locally on the endpoint.
+2. Matches are packaged into an **encrypted payload** before transmission — encryption is applied at the application layer in addition to TLS.
+3. The encrypted payload is delivered to the Telivy platform, where it is decrypted and stored against the device record.
+4. Authorized users in your tenant view findings through `ApplicationAccess`-controlled portal endpoints.
+
+Cleartext passwords from the password-analysis module, by contrast, are **never** transmitted off the device — only their hashes are. PII match samples follow a different design choice because confirming and remediating PII findings requires being able to see *what was matched*. We're transparent about that distinction so you can make the right call for each client.
+
+If that default is the wrong fit for a specific client or your entire book, you can change it.
+
+---
+
+## Mask PII Data — the supported privacy control
+
+Telivy provides a **Mask PII Data** setting at both the agency level and the per-assessment level. When enabled, the platform redacts the literal match values everywhere they would otherwise be displayed — the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. **Counts, file paths, device names, and dollar-risk valuations are still shown** so the finding remains actionable.
+
+The toggle is labeled **"Mask PII Data (may be required under HIPAA)"** and is the right setting for:
+
+- HIPAA-sensitive partners or any client with regulated PHI
+- Partners whose vendor risk program prohibits a third-party platform from storing or displaying production PII
+- MSPs who want a consistent privacy posture across their book regardless of individual client requirements
+
+### Where to configure it
+
+**Agency level (recommended for partners who want this on by default for all clients):**
+
+Navigate to **Account Settings → PII Configuration → Configure PII Costs**, and enable **Mask PII Data**.
+
+**Assessment level (for client-by-client overrides):**
+
+Open the specific assessment, navigate to its PII configuration, and enable **Mask PII Data** for that assessment alone.
+
+### Important: this setting requires a rescan to take effect
+
+The PII configuration modal explicitly notes that toggling **Mask PII Data** does not retroactively redact already-captured matches. After enabling the setting, run **Rescan All** on the affected assessments to refresh the data. New scans honor the masking from the moment of capture; old scan results retain whatever they captured at the time.
+
+For partners turning this on as a baseline policy, the right rollout is: enable at the agency level → notify your team → trigger a rescan on each active assessment → verify the **Data Found** view in a sample finding shows redacted output before considering the change complete.
+
+### Adjacent control: Mask Dark Web Passwords
+
+The PII Configuration screen also offers a separate **Mask Dark Web Passwords** toggle. This affects how dark-web finding evidence is displayed (the same masking concept applied to leaked-credential evidence). It's independent from Mask PII Data — turning one on does not turn the other on.
+
+---
+
+## Per-type cost weights
+
+Beyond masking, the **Configure PII Costs** modal lets you adjust the dollar valuation per record by PII type, currency, and region. These weights drive the **dollar-risk** column in the grid and the rolled-up exposure value used in the assessment's data-security grade.
+
+Cost weight changes take effect immediately — they don't require a rescan, because the underlying match data isn't changing, only the valuation logic on top of it.
+
+Adjust weights when:
+
+- Your client is in a regulated vertical with known per-record fines that differ from defaults (for example, healthcare PHI under HIPAA breach valuations).
+- Your client's region uses a different currency or has different regulatory liability ranges.
+- You want a more conservative dollar-risk display in QBR materials.
+
+---
+
+## How MSPs use this in practice — Analyze → Prioritize → Commit
+
+**Analyze.** Filter the Data Risk view by device. Identify the small number of machines with disproportionate exposure — typically file servers, finance/HR laptops, and old endpoints that accumulated years of CSV exports. The 80/20 holds: a handful of devices usually account for the majority of dollar-risk.
+
+**Prioritize.** Sort by dollar-risk, not match count. A single 50,000-row export with one match per row inflates counts but represents one file. Pair Data Security findings with **disk encryption** findings — an unencrypted laptop with high PII exposure is the urgent ticket.
+
+**Commit.** Drive remediation through the obvious paths:
+
+- **Delete or archive** stale exports that don't need to be on endpoints.
+- **Move** active datasets into managed cloud storage with access controls.
+- **Encrypt** any device holding regulated PII (BitLocker / FileVault).
+- **Tighten access** on the file server — finance shouldn't have read on HR exports, and vice versa.
+
+The next scan will close the finding automatically when the underlying file is gone or moved.
+
+---
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Does Telivy store the actual PII values it finds (like credit card numbers)?">
+    By default, yes — the matched value is captured along with file path, device, and PII type so that your tech can verify the finding isn't a false positive and drive remediation with the SMB. The transmission from agent to platform is encrypted at the application layer, and access to the data inside the platform is gated by `ApplicationAccess` controls.
+
+    If you don't want literal match values displayed in the platform, enable **Mask PII Data** at the agency or assessment level and rescan. With masking on, counts, file paths, devices, and dollar-risk are still shown — only the literal match values are redacted.
+  </Accordion>
+
+  <Accordion title="How do I enable Mask PII Data for an entire client base?">
+    Set it at the **agency level** in **Account Settings → PII Configuration → Configure PII Costs**. The setting will inherit down to every existing and future assessment unless you explicitly override it at the assessment level. After enabling, run **Rescan All** on each active assessment so already-captured findings refresh under the new masking rule.
+  </Accordion>
+
+  <Accordion title="Will Mask PII Data hide findings or just the values?">
+    Just the values. Findings still appear, devices and file paths are still listed, match counts are still shown, and dollar-risk is still calculated. The change is to the **Data Found** display and the per-match values in exports — the actionable portion of the finding remains intact.
+  </Accordion>
+
+  <Accordion title="Why does Telivy capture match samples by default at all?">
+    Because false positives matter. A regex that flags every Luhn-valid 16-digit string will hit on test files, sample data, and code. Without a sample, your tech can't confirm whether a finding is a real production card number or a developer's `4111-1111-1111-1111`. Without that confirmation, the alternative is escalating every match as a real breach — which destroys the credibility of the report. The supported answer for partners who don't want to take custody of literal values is **Mask PII Data**.
+  </Accordion>
+
+  <Accordion title="Are passwords handled the same way as PII?">
+    No. Cleartext passwords are **never** transmitted from the device — Telivy stores only hashes for the password-analysis features. PII matches follow a different design as described above. The two are governed by separate controls (**Mask PII Data** for PII, **Mask Dark Web Passwords** for password evidence), so you can configure each according to your partner's needs.
+  </Accordion>
+
+  <Accordion title="Does the dollar-risk valuation update without rescanning?">
+    Yes. Cost-weight changes recompute the dollar-risk display immediately — they don't require a rescan, because they only change valuation logic, not the underlying matches. The **Mask PII Data** setting is the one that requires Rescan All to take effect.
+  </Accordion>
+
+  <Accordion title="What if the agent runs without admin privileges?">
+    In agentless mode (or any scenario where the scanner lacks elevation), Telivy can only inspect files readable by the local user account. Production fileservers and other shared locations may be missed. For full Data Security coverage, deploy the agent under a context that can read the data your client cares about.
+  </Accordion>
+</AccordionGroup>

--- a/products/risk-assessments/data-security.mdx
+++ b/products/risk-assessments/data-security.mdx
@@ -3,13 +3,13 @@ title: "Data Security"
 description: "How Telivy detects PII on a client's endpoints, what evidence the platform stores and displays, and how to control it for HIPAA-sensitive partners."
 ---
 
-Data Security is the part of a Telivy Risk Assessment that finds personally identifiable information sitting on the wrong machines, in the wrong folders — and quantifies what it would cost the client if any of those machines got lost, stolen, or compromised. This page explains exactly what Telivy scans, what evidence is captured, what shows up in the platform, and how to configure it for partners with stricter privacy or HIPAA requirements.
+Data Security is the part of a Telivy Risk Assessment that finds personally identifiable information sitting on the wrong machines, in the wrong folders, and quantifies what it would cost the client if any of those machines got lost, stolen, or compromised. This page explains exactly what Telivy scans, what evidence is captured, what shows up in the platform, and how to configure it for partners with stricter privacy or HIPAA requirements.
 
 ---
 
 ## Overview
 
-The Telivy agent inspects files on each endpoint during its scan and identifies content that matches recognized PII patterns: credit card numbers, Social Security numbers (and Canadian SIN equivalents), email addresses, phone numbers, and other regulated identifiers. For each match, Telivy captures the **file path**, the **device**, the **PII type**, the **match count**, and a **dollar-risk valuation** based on per-record liability assumptions. Findings roll up into a per-device and per-client view your tech can act on — and that an MSP can put in front of an SMB owner during a QBR or insurance renewal.
+The Telivy agent inspects files on each endpoint during its scan and identifies content that matches recognized PII patterns: credit card numbers, Social Security numbers (and Canadian SIN equivalents), email addresses, phone numbers, and other regulated identifiers. For each match, Telivy captures the **file path**, the **device**, the **PII type**, the **match count**, and a **dollar-risk valuation** based on per-record liability assumptions. Findings roll up into a per-device and per-client view your tech can act on, and that an MSP can put in front of an SMB owner during a QBR or insurance renewal.
 
 The output is the conversation that gets cyber insurance approved: *"Your client has 14,000 records of regulated PII spread across 22 laptops, and three of those laptops are unencrypted. That's the carrier's first question."*
 
@@ -36,7 +36,7 @@ Telivy classifies findings by PII type. The most common categories:
 | **Personal contact data** | Email addresses, phone numbers |
 | **Other regulated identifiers** | Drivers license, passport, tax ID patterns by region |
 
-Each finding is enriched with a **dollar-risk valuation** — a per-record liability estimate that lets the platform roll up "this client has \$1.2M of exposure on this one fileserver" rather than just "this client has 14,000 records." You can adjust the per-record weights in the **Configure PII Costs** modal (covered below).
+Each finding is enriched with a **dollar-risk valuation**: a per-record liability estimate that lets the platform roll up "this client has \$1.2M of exposure on this one fileserver" rather than just "this client has 14,000 records." You can adjust the per-record weights in the **Configure PII Costs** modal (covered below).
 
 ---
 
@@ -44,33 +44,33 @@ Each finding is enriched with a **dollar-risk valuation** — a per-record liabi
 
 The Data Risk experience has two views, deliberately separated:
 
-1. **The grid view** (Data Risk modal). Columns include device, file path, file size, last modified, PII type, **match count**, and dollar-risk. The actual matched values are **not** shown in the grid — only the count.
-2. **The detail view** (per-file modal, opened with **View**). Shows full file metadata plus a **Data Found** section that displays the matched values themselves (for example, the literal numbers a credit-card pattern matched on). This is the screen your tech uses to confirm a finding isn't a false positive — a Luhn-valid string in a code sample, an old testing export, a year-end CSV that should have been purged.
+1. **The grid view** (Data Risk modal). Columns include device, file path, file size, last modified, PII type, **match count**, and dollar-risk. The actual matched values are **not** shown in the grid; only the count.
+2. **The detail view** (per-file modal, opened with **View**). Shows full file metadata plus a **Data Found** section that displays the matched values themselves (for example, the literal numbers a credit-card pattern matched on). This is the screen your tech uses to confirm a finding isn't a false positive: a Luhn-valid string in a code sample, an old testing export, a year-end CSV that should have been purged.
 
 **Reports and exports.** The CSV PII report includes columns by category (Credit Card Matches, SSN/ID Matches, Email Matches, etc.) and is intended for the same operational use as the detail view: confirming materiality and routing remediation.
 
 ---
 
-## Privacy & custody — what leaves the device
+## Privacy & custody: what leaves the device
 
 This is the section to read carefully if your partner is HIPAA-sensitive, has a strict vendor risk program, or has asked the question directly.
 
 **By default**, Telivy is designed to give the MSP enough evidence to confirm that a finding is real and to drive remediation. That includes capturing **a sample of the matched value** along with file path, device, and PII type. The data flow is:
 
 1. The Telivy agent scans files locally on the endpoint.
-2. Matches are packaged into an **encrypted payload** before transmission — encryption is applied at the application layer in addition to TLS.
+2. Matches are packaged into an **encrypted payload** before transmission; encryption is applied at the application layer in addition to TLS.
 3. The encrypted payload is delivered to the Telivy platform, where it is decrypted and stored against the device record.
 4. Authorized users in your tenant view findings through `ApplicationAccess`-controlled portal endpoints.
 
-Cleartext passwords from the password-analysis module, by contrast, are **never** transmitted off the device — only their hashes are. PII match samples follow a different design choice because confirming and remediating PII findings requires being able to see *what was matched*. We're transparent about that distinction so you can make the right call for each client.
+Cleartext passwords from the password-analysis module, by contrast, are **never** transmitted off the device; only their hashes are. PII match samples follow a different design choice because confirming and remediating PII findings requires being able to see *what was matched*. We're transparent about that distinction so you can make the right call for each client.
 
 If that default is the wrong fit for a specific client or your entire book, you can change it.
 
 ---
 
-## Mask PII Data — the supported privacy control
+## Mask PII Data: the supported privacy control
 
-Telivy provides a **Mask PII Data** setting at both the agency level and the per-assessment level. When enabled, the platform redacts the literal match values everywhere they would otherwise be displayed — the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. **Counts, file paths, device names, and dollar-risk valuations are still shown** so the finding remains actionable.
+Telivy provides a **Mask PII Data** setting at both the agency level and the per-assessment level. When enabled, the platform redacts the literal match values everywhere they would otherwise be displayed: the **Data Found** detail view, CSV exports, and any other surface that would have shown the raw match. **Counts, file paths, device names, and dollar-risk valuations are still shown** so the finding remains actionable.
 
 The toggle is labeled **"Mask PII Data (may be required under HIPAA)"** and is the right setting for:
 
@@ -96,7 +96,7 @@ For partners turning this on as a baseline policy, the right rollout is: enable 
 
 ### Adjacent control: Mask Dark Web Passwords
 
-The PII Configuration screen also offers a separate **Mask Dark Web Passwords** toggle. This affects how dark-web finding evidence is displayed (the same masking concept applied to leaked-credential evidence). It's independent from Mask PII Data — turning one on does not turn the other on.
+The PII Configuration screen also offers a separate **Mask Dark Web Passwords** toggle. This affects how dark-web finding evidence is displayed (the same masking concept applied to leaked-credential evidence). It's independent from Mask PII Data. Turning one on does not turn the other on.
 
 ---
 
@@ -104,7 +104,7 @@ The PII Configuration screen also offers a separate **Mask Dark Web Passwords** 
 
 Beyond masking, the **Configure PII Costs** modal lets you adjust the dollar valuation per record by PII type, currency, and region. These weights drive the **dollar-risk** column in the grid and the rolled-up exposure value used in the assessment's data-security grade.
 
-Cost weight changes take effect immediately — they don't require a rescan, because the underlying match data isn't changing, only the valuation logic on top of it.
+Cost weight changes take effect immediately. They don't require a rescan, because the underlying match data isn't changing, only the valuation logic on top of it.
 
 Adjust weights when:
 
@@ -114,18 +114,18 @@ Adjust weights when:
 
 ---
 
-## How MSPs use this in practice — Analyze → Prioritize → Commit
+## How MSPs use this in practice: Analyze → Prioritize → Commit
 
-**Analyze.** Filter the Data Risk view by device. Identify the small number of machines with disproportionate exposure — typically file servers, finance/HR laptops, and old endpoints that accumulated years of CSV exports. The 80/20 holds: a handful of devices usually account for the majority of dollar-risk.
+**Analyze.** Filter the Data Risk view by device. Identify the small number of machines with disproportionate exposure: typically file servers, finance/HR laptops, and old endpoints that accumulated years of CSV exports. The 80/20 holds: a handful of devices usually account for the majority of dollar-risk.
 
-**Prioritize.** Sort by dollar-risk, not match count. A single 50,000-row export with one match per row inflates counts but represents one file. Pair Data Security findings with **disk encryption** findings — an unencrypted laptop with high PII exposure is the urgent ticket.
+**Prioritize.** Sort by dollar-risk, not match count. A single 50,000-row export with one match per row inflates counts but represents one file. Pair Data Security findings with **disk encryption** findings: an unencrypted laptop with high PII exposure is the urgent ticket.
 
 **Commit.** Drive remediation through the obvious paths:
 
 - **Delete or archive** stale exports that don't need to be on endpoints.
 - **Move** active datasets into managed cloud storage with access controls.
 - **Encrypt** any device holding regulated PII (BitLocker / FileVault).
-- **Tighten access** on the file server — finance shouldn't have read on HR exports, and vice versa.
+- **Tighten access** on the file server: finance shouldn't have read on HR exports, and vice versa.
 
 The next scan will close the finding automatically when the underlying file is gone or moved.
 
@@ -135,9 +135,9 @@ The next scan will close the finding automatically when the underlying file is g
 
 <AccordionGroup>
   <Accordion title="Does Telivy store the actual PII values it finds (like credit card numbers)?">
-    By default, yes — the matched value is captured along with file path, device, and PII type so that your tech can verify the finding isn't a false positive and drive remediation with the SMB. The transmission from agent to platform is encrypted at the application layer, and access to the data inside the platform is gated by `ApplicationAccess` controls.
+    By default, yes. The matched value is captured along with file path, device, and PII type so that your tech can verify the finding isn't a false positive and drive remediation with the SMB. The transmission from agent to platform is encrypted at the application layer, and access to the data inside the platform is gated by `ApplicationAccess` controls.
 
-    If you don't want literal match values displayed in the platform, enable **Mask PII Data** at the agency or assessment level and rescan. With masking on, counts, file paths, devices, and dollar-risk are still shown — only the literal match values are redacted.
+    If you don't want literal match values displayed in the platform, enable **Mask PII Data** at the agency or assessment level and rescan. With masking on, counts, file paths, devices, and dollar-risk are still shown; only the literal match values are redacted.
   </Accordion>
 
   <Accordion title="How do I enable Mask PII Data for an entire client base?">
@@ -145,19 +145,19 @@ The next scan will close the finding automatically when the underlying file is g
   </Accordion>
 
   <Accordion title="Will Mask PII Data hide findings or just the values?">
-    Just the values. Findings still appear, devices and file paths are still listed, match counts are still shown, and dollar-risk is still calculated. The change is to the **Data Found** display and the per-match values in exports — the actionable portion of the finding remains intact.
+    Just the values. Findings still appear, devices and file paths are still listed, match counts are still shown, and dollar-risk is still calculated. The change is to the **Data Found** display and the per-match values in exports; the actionable portion of the finding remains intact.
   </Accordion>
 
   <Accordion title="Why does Telivy capture match samples by default at all?">
-    Because false positives matter. A regex that flags every Luhn-valid 16-digit string will hit on test files, sample data, and code. Without a sample, your tech can't confirm whether a finding is a real production card number or a developer's `4111-1111-1111-1111`. Without that confirmation, the alternative is escalating every match as a real breach — which destroys the credibility of the report. The supported answer for partners who don't want to take custody of literal values is **Mask PII Data**.
+    Because false positives matter. A regex that flags every Luhn-valid 16-digit string will hit on test files, sample data, and code. Without a sample, your tech can't confirm whether a finding is a real production card number or a developer's `4111-1111-1111-1111`. Without that confirmation, the alternative is escalating every match as a real breach, which destroys the credibility of the report. The supported answer for partners who don't want to take custody of literal values is **Mask PII Data**.
   </Accordion>
 
   <Accordion title="Are passwords handled the same way as PII?">
-    No. Cleartext passwords are **never** transmitted from the device — Telivy stores only hashes for the password-analysis features. PII matches follow a different design as described above. The two are governed by separate controls (**Mask PII Data** for PII, **Mask Dark Web Passwords** for password evidence), so you can configure each according to your partner's needs.
+    No. Cleartext passwords are **never** transmitted from the device; Telivy stores only hashes for the password-analysis features. PII matches follow a different design as described above. The two are governed by separate controls (**Mask PII Data** for PII, **Mask Dark Web Passwords** for password evidence), so you can configure each according to your partner's needs.
   </Accordion>
 
   <Accordion title="Does the dollar-risk valuation update without rescanning?">
-    Yes. Cost-weight changes recompute the dollar-risk display immediately — they don't require a rescan, because they only change valuation logic, not the underlying matches. The **Mask PII Data** setting is the one that requires Rescan All to take effect.
+    Yes. Cost-weight changes recompute the dollar-risk display immediately. They don't require a rescan, because they only change valuation logic, not the underlying matches. The **Mask PII Data** setting is the one that requires Rescan All to take effect.
   </Accordion>
 
   <Accordion title="What if the agent runs without admin privileges?">


### PR DESCRIPTION
## Summary

Adds the supported answers to recurring partner due-diligence questions about vulnerability provenance and PII custody. Originated from a partner asking us, in writing, where our CVE data comes from and whether literal PII evidence (like credit card numbers) leaves the client environment.

### What's in this PR

- **New Learning Center page — `learning-center/vulnerability-data-sources.mdx`**
  Documents the three data sources behind every CVE finding: the CVE Program (`cvelistV5`) as the authoritative catalog, Vulners (via Nmap) for scan-time correlation, EPSS for prioritization, and NVD for reference links. Frames it for an MSP audience: where the data comes from, why CVSS-only ranking misses the actual risk, and how to lead a defensible prioritization conversation with a client. **KEV is intentionally omitted** — leave it out until it's wired into scoring in production.

- **New Risk Assessments product page — `products/risk-assessments/data-security.mdx`**
  Documents what the agent scans for PII, how matches appear in the platform (grid view shows counts only; the **Data Found** detail view shows literal match samples for false-positive triage), and the privacy/custody flow end-to-end. **Documents `Mask PII Data` as the supported privacy control** for HIPAA-sensitive partners, with the full agency/assessment configuration walkthrough and the **Rescan All** caveat. Includes an FAQ block covering the most likely partner follow-ups.

- **Three new FAQ accordions in `frequently-asked-questions/risk-assessments-and-external-scans.mdx`**
  - "What CVE Database Does Telivy Use?"
  - "Does Telivy Store The Actual PII It Finds (Like Credit Card Numbers)?"
  - "Can I Prevent PII Evidence From Being Shown In The Platform?"

- **`docs.json`** — wires both new pages into Learning Center and Risk Assessments navigation.

### Out of scope (deliberately)

- No release note `<Update>` block (per direction).
- No KEV references anywhere.
- No claims about field-level at-rest encryption, retention/auto-delete policies, or SOC 2 attestations — those aren't verifiable in code today.
- No screenshots yet — follow-up to capture the PII Configuration modal and add to `images/`.

### Important follow-up before/after merge

The Data Security page commits to: when `Mask PII Data` is on, raw match values are redacted from the **Data Found** view *and* CSV exports. The `maskPii` flag is present on entities/migrations and at agent capture, but the server-side read paths (matches list, CSV export) should be confirmed to honor it end-to-end. **If there's a gap, that's now a documented contract — recommend opening an eng task to verify and close any gap before publishing widely.**

## Test plan

- [ ] Mintlify preview renders both new pages without component errors
- [ ] Both new pages appear in the navigation under the expected groups (Learning Center; Risk Assessments)
- [ ] Internal links in the FAQ accordions resolve to the new pages (`/learning-center/vulnerability-data-sources` and `/products/risk-assessments/data-security`)
- [ ] Voice/style spot-check by a reviewer familiar with the docs-writer skill
- [ ] Eng confirms `maskPii` is enforced on server-side read paths (matches list, CSV export) — track separately

Made with [Cursor](https://cursor.com)