### PR TITLE
Add Risk Monitoring and Alerts documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -88,6 +88,13 @@
                   "products/lead-magnet/configure-with-custom-form",
                   "products/lead-magnet/track-submissions-with-utm-source"
                 ]
+              },
+              {
+                "group": "Risk Monitoring",
+                "pages": [
+                  "products/risk-monitoring/overview",
+                  "products/risk-monitoring/alerts"
+                ]
               }
             ]
           },

--- a/products/risk-monitoring/alerts.mdx
+++ b/products/risk-monitoring/alerts.mdx
@@ -7,14 +7,14 @@ description: "Get notified the moment something worth your attention happens acr
 
 Rescans tell you how a client's posture has shifted over a period. Alerts tell you right now.
 
-When Telivy detects a specific security event — a new dark web breach, a string of M365 login failures, an admin account with MFA suddenly disabled — it fires a notification to whoever on your team needs to know. You define which events matter and which team members get notified.
+When Telivy detects a specific security event (a new dark web breach, a string of M365 login failures, an admin account with MFA suddenly disabled), it fires a notification to whoever on your team needs to know. You define which events matter and which team members get notified.
 
 Alerts work across four coverage areas:
 
-- **Internal Security** — vulnerability changes on managed endpoints
-- **Dark Web** — new breach and account exposures
-- **Microsoft 365** — identity, access, and policy events across connected tenants
-- **Google Workspace** — the same coverage for GWS environments
+- **Internal Security**: vulnerability changes on managed endpoints
+- **Dark Web**: new breach and account exposures
+- **Microsoft 365**: identity, access, and policy events across connected tenants
+- **Google Workspace**: the same coverage for GWS environments
 
 ## Configuring Alert Policies
 
@@ -24,14 +24,14 @@ To add a new policy:
 
 1. Click **Add Policy**.
 2. In the **Configure Alert Policy** step, select the **Alert Category** you want to monitor.
-3. Set the condition that triggers the alert — for example, for Internal Vulnerabilities you can trigger on severity level, CVSS score, EPSS score, or finding count above a threshold.
+3. Set the condition that triggers the alert. For Internal Vulnerabilities, for example, you can trigger on severity level, CVSS score, EPSS score, or finding count above a threshold.
 4. Click **Continue**.
 5. In the **Configure Alert Delivery** step, select which team members on your agency account should receive the notification.
 6. Click **Save**.
 
 You can view alert history for a specific client by opening that assessment and navigating to the **Alerts** tab.
 
-Alerts fire as soon as Telivy detects the triggering event — during a scheduled rescan, a cloud sync, or when the agent reports new data.
+Alerts fire as soon as Telivy detects the triggering event: during a scheduled rescan, a cloud sync, or when the agent reports new data.
 
 ## Alert Categories
 
@@ -111,7 +111,7 @@ Google Workspace alerts mirror the M365 coverage for organizations running GWS i
   </Accordion>
 
   <Accordion title="What's the difference between 'Failed Logins' and 'Conditional Access Violation'?">
-    Failed Logins fire when a user fails to authenticate — wrong password, locked account, etc. Conditional Access Violation fires when the credentials are valid but the sign-in is blocked by a policy rule (e.g. the user is signing in from an unmanaged device or blocked location). Both matter; they indicate different threat patterns.
+    Failed Logins fire when a user fails to authenticate: wrong password, locked account, etc. Conditional Access Violation fires when the credentials are valid but the sign-in is blocked by a policy rule (e.g. the user is signing in from an unmanaged device or blocked location). Both matter; they indicate different threat patterns.
   </Accordion>
 
   <Accordion title="Can I use webhooks instead of email or SMS?">

--- a/products/risk-monitoring/alerts.mdx
+++ b/products/risk-monitoring/alerts.mdx
@@ -1,0 +1,120 @@
+---
+title: "Alerts"
+description: "Get notified the moment something worth your attention happens across a client's endpoints, dark web exposure, Microsoft 365, and Google Workspace."
+---
+
+## Overview
+
+Rescans tell you how a client's posture has shifted over a period. Alerts tell you right now.
+
+When Telivy detects a specific security event — a new dark web breach, a string of M365 login failures, an admin account with MFA suddenly disabled — it fires a notification to whoever on your team needs to know. You define which events matter and which team members get notified.
+
+Alerts work across four coverage areas:
+
+- **Internal Security** — vulnerability changes on managed endpoints
+- **Dark Web** — new breach and account exposures
+- **Microsoft 365** — identity, access, and policy events across connected tenants
+- **Google Workspace** — the same coverage for GWS environments
+
+## Configuring Alert Policies
+
+Alert policies are configured at the agency level and apply across all your assessments. Navigate to **Alerts → Alert Policies** in the Telivy portal to manage them.
+
+To add a new policy:
+
+1. Click **Add Policy**.
+2. In the **Configure Alert Policy** step, select the **Alert Category** you want to monitor.
+3. Set the condition that triggers the alert — for example, for Internal Vulnerabilities you can trigger on severity level, CVSS score, EPSS score, or finding count above a threshold.
+4. Click **Continue**.
+5. In the **Configure Alert Delivery** step, select which team members on your agency account should receive the notification.
+6. Click **Save**.
+
+You can view alert history for a specific client by opening that assessment and navigating to the **Alerts** tab.
+
+Alerts fire as soon as Telivy detects the triggering event — during a scheduled rescan, a cloud sync, or when the agent reports new data.
+
+## Alert Categories
+
+### Internal Security
+
+| Alert | What triggers it |
+|---|---|
+| Internal Vulnerabilities | New CVEs discovered on managed endpoints during a scan |
+
+### Dark Web
+
+| Alert | What triggers it |
+|---|---|
+| Dark Web Breach | A client domain or asset appears in a newly indexed data breach |
+| Dark Web Account | A specific user account credential is found in a breach dataset |
+
+### Microsoft 365
+
+| Alert | What triggers it |
+|---|---|
+| Failed Logins | A user account records repeated failed sign-in attempts |
+| Authentication Token Revoked | An active session or refresh token is revoked |
+| Conditional Access Violation | A sign-in attempt is blocked by a Conditional Access policy |
+| MFA Failed | A user fails an MFA challenge |
+| MFA Disabled | MFA is turned off for a user account |
+| MFA Enabled | MFA is turned on for a user account |
+| No MFA User | A user account is detected without any MFA method enrolled |
+| Password Reset | A user password is reset |
+| Login Using Token | A sign-in occurs via token rather than interactive credential |
+| Login From Unapproved Location | A sign-in originates from a geography outside the client's approved list |
+| User Created | A new user account is added to the tenant |
+| User Deleted | A user account is removed from the tenant |
+| Registered Device | A new device is registered to the tenant |
+| Admin Role Assignment | A user is granted an admin role |
+| Group Membership Change | A user is added to or removed from a security group |
+| Admin Policy Change | A tenant-level security policy is modified by an admin |
+
+### Google Workspace
+
+Google Workspace alerts mirror the M365 coverage for organizations running GWS instead of (or alongside) Microsoft 365.
+
+| Alert | What triggers it |
+|---|---|
+| Failed Logins | Repeated failed sign-in attempts on a GWS account |
+| Authentication Token Revoked | An OAuth token or session is revoked |
+| MFA Failed | A user fails a GWS MFA challenge |
+| MFA Disabled | MFA is removed from a GWS account |
+| MFA Enabled | MFA is added to a GWS account |
+| No MFA User | A GWS account has no MFA enrolled |
+| Password Reset | A GWS user password is reset |
+| Login Using Token | A sign-in via token rather than interactive credential |
+| Login From Unapproved Location | Sign-in from outside an approved geography |
+| User Created | A new GWS user is provisioned |
+| User Deleted | A GWS user account is removed |
+| Registered Device | A new device is registered in GWS |
+| Admin Role Assignment | A user is granted admin privileges in GWS |
+| Group Membership Change | A user is added to or removed from a GWS group |
+| Admin Policy Change | A GWS admin-level policy is modified |
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="How quickly does an alert fire after an event is detected?">
+    Cloud events (M365, Google Workspace) are evaluated on each sync cycle. Endpoint-based alerts (Internal Vulnerabilities) are evaluated after each completed agent scan. Manual rescans trigger alert evaluation immediately.
+  </Accordion>
+
+  <Accordion title="Can I notify multiple team members from the same policy?">
+    Yes. In the Configure Alert Delivery step, you can select as many agency users as needed. Each selected user is notified independently when the policy triggers.
+  </Accordion>
+
+  <Accordion title="Are alert policies scoped to individual clients?">
+    No. Policies are configured at the agency level and apply across all assessments. You can view alert history filtered to a specific client from that assessment's Alerts tab, but the policy itself is agency-wide.
+  </Accordion>
+
+  <Accordion title="Do alerts require Risk Monitoring to be enabled?">
+    No. Alerts are available independently of the automated rescan feature. You can configure alerts on any eligible Risk Assessment without enabling the monitoring cadence.
+  </Accordion>
+
+  <Accordion title="What's the difference between 'Failed Logins' and 'Conditional Access Violation'?">
+    Failed Logins fire when a user fails to authenticate — wrong password, locked account, etc. Conditional Access Violation fires when the credentials are valid but the sign-in is blocked by a policy rule (e.g. the user is signing in from an unmanaged device or blocked location). Both matter; they indicate different threat patterns.
+  </Accordion>
+
+  <Accordion title="Can I use webhooks instead of email or SMS?">
+    Yes. Telivy supports outbound webhooks for alert delivery to external systems. See the [Webhooks](/integrations/webhooks) integration guide for configuration details.
+  </Accordion>
+</AccordionGroup>

--- a/products/risk-monitoring/overview.mdx
+++ b/products/risk-monitoring/overview.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Risk Monitoring"
-description: "Keep a live pulse on every client's security posture — automated rescans on your schedule, with real-time alerts when something worth your attention happens."
+description: "Keep a live pulse on every client's security posture, with automated rescans on your schedule and real-time alerts when something worth your attention happens."
 ---
 
 ## Overview
 
 A point-in-time assessment tells you where a client stands today. Risk Monitoring keeps that picture current.
 
-When Risk Monitoring is enabled for an assessment, Telivy automatically rescans the client on a cadence you control. Pair that with [Alerts](/products/risk-monitoring/alerts) — which fire the moment a specific security event is detected — and you shift from reactive to proactive without adding manual effort.
+When Risk Monitoring is enabled for an assessment, Telivy automatically rescans the client on a cadence you control. Pair that with [Alerts](/products/risk-monitoring/alerts), which fire the moment a specific security event is detected, and you shift from reactive to proactive without adding manual effort.
 
 ## Requirements
 
 | Requirement | Detail |
 |---|---|
 | Assessment type | Risk Assessment (not applicable to External-only or Lead Magnet assessments) |
-| Agency plan | Risk Monitoring must be enabled on your Telivy account — contact [accounts@telivy.com](mailto:accounts@telivy.com) to activate |
+| Agency plan | Risk Monitoring must be enabled on your Telivy account; contact [accounts@telivy.com](mailto:accounts@telivy.com) to activate |
 | Telivy Agent | Agent must be deployed and reporting on the target assessment |
 
 ## Configuring Scan Frequency
@@ -29,7 +29,7 @@ Once Risk Monitoring is enabled on your account, each assessment gets a **Scan S
 | Frequency | Best for |
 |---|---|
 | Weekly | High-risk clients, clients under active remediation, or clients with a recent incident |
-| Monthly | Standard managed clients — balances coverage with noise |
+| Monthly | Standard managed clients: balances coverage with noise |
 | Quarterly | Low-complexity clients or assessments used primarily for annual reviews |
 | Disable | Assessments where you want manual-only control |
 
@@ -38,7 +38,7 @@ Frequency is set per assessment, so each client can run on its own schedule. You
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="I don't see the Scan Settings button — why?">
+  <Accordion title="I don't see the Scan Settings button. Why?">
     The Scan Settings button only appears when Risk Monitoring is active on your agency account. If you don't see it, reach out to [accounts@telivy.com](mailto:accounts@telivy.com) to get it enabled.
   </Accordion>
 
@@ -46,8 +46,8 @@ Frequency is set per assessment, so each client can run on its own schedule. You
     No. Automated rescans are part of the monitoring cadence and do not create new billable assessments. They update the existing assessment's findings.
   </Accordion>
 
-  <Accordion title="What gets rescanned — the full assessment or just selected checks?">
-    A rescan runs the full suite of checks included in the original assessment. If the assessment has an agent deployed and cloud integrations connected (M365, Google Workspace), those are all included. Note that a rescan **replaces** the existing assessment data — it does not create a separate snapshot or historical record alongside the current one.
+  <Accordion title="What gets rescanned: the full assessment or just selected checks?">
+    A rescan runs the full suite of checks included in the original assessment. If the assessment has an agent deployed and cloud integrations connected (M365, Google Workspace), those are all included. Note that a rescan **replaces** the existing assessment data. It does not create a separate snapshot or historical record alongside the current one.
   </Accordion>
 
   <Accordion title="Can I set different scan frequencies for different clients?">
@@ -55,6 +55,6 @@ Frequency is set per assessment, so each client can run on its own schedule. You
   </Accordion>
 
   <Accordion title="How do I get notified when a rescan finds something new?">
-    Use [Alerts](/products/risk-monitoring/alerts) to get notified for specific security events — new vulnerabilities, dark web exposures, M365 and Google Workspace activity.
+    Use [Alerts](/products/risk-monitoring/alerts) to get notified for specific security events: new vulnerabilities, dark web exposures, M365 and Google Workspace activity.
   </Accordion>
 </AccordionGroup>

--- a/products/risk-monitoring/overview.mdx
+++ b/products/risk-monitoring/overview.mdx
@@ -1,5 +1,60 @@
 ---
-title: 'What is Risk Monitoring?'
-description: 'Rescans and their Benefits'
+title: "Risk Monitoring"
+description: "Keep a live pulse on every client's security posture — automated rescans on your schedule, with real-time alerts when something worth your attention happens."
 ---
 
+## Overview
+
+A point-in-time assessment tells you where a client stands today. Risk Monitoring keeps that picture current.
+
+When Risk Monitoring is enabled for an assessment, Telivy automatically rescans the client on a cadence you control. Pair that with [Alerts](/products/risk-monitoring/alerts) — which fire the moment a specific security event is detected — and you shift from reactive to proactive without adding manual effort.
+
+## Requirements
+
+| Requirement | Detail |
+|---|---|
+| Assessment type | Risk Assessment (not applicable to External-only or Lead Magnet assessments) |
+| Agency plan | Risk Monitoring must be enabled on your Telivy account — contact [accounts@telivy.com](mailto:accounts@telivy.com) to activate |
+| Telivy Agent | Agent must be deployed and reporting on the target assessment |
+
+## Configuring Scan Frequency
+
+Once Risk Monitoring is enabled on your account, each assessment gets a **Scan Settings** button in the assessment header. Use it to set how often Telivy automatically rescans that client.
+
+1. Open the assessment in the Telivy portal.
+2. Click **Scan Settings** in the top right of the assessment header.
+3. Under **Automated Scan Frequency**, choose your cadence.
+4. Click **Save**.
+
+| Frequency | Best for |
+|---|---|
+| Weekly | High-risk clients, clients under active remediation, or clients with a recent incident |
+| Monthly | Standard managed clients — balances coverage with noise |
+| Quarterly | Low-complexity clients or assessments used primarily for annual reviews |
+| Disable | Assessments where you want manual-only control |
+
+Frequency is set per assessment, so each client can run on its own schedule. You can trigger a manual rescan at any time regardless of the cadence.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="I don't see the Scan Settings button — why?">
+    The Scan Settings button only appears when Risk Monitoring is active on your agency account. If you don't see it, reach out to [accounts@telivy.com](mailto:accounts@telivy.com) to get it enabled.
+  </Accordion>
+
+  <Accordion title="Does a rescan count as a new assessment for billing purposes?">
+    No. Automated rescans are part of the monitoring cadence and do not create new billable assessments. They update the existing assessment's findings.
+  </Accordion>
+
+  <Accordion title="What gets rescanned — the full assessment or just selected checks?">
+    A rescan runs the full suite of checks included in the original assessment. If the assessment has an agent deployed and cloud integrations connected (M365, Google Workspace), those are all included. Note that a rescan **replaces** the existing assessment data — it does not create a separate snapshot or historical record alongside the current one.
+  </Accordion>
+
+  <Accordion title="Can I set different scan frequencies for different clients?">
+    Yes. Frequency is per assessment, so each client can have its own cadence independently.
+  </Accordion>
+
+  <Accordion title="How do I get notified when a rescan finds something new?">
+    Use [Alerts](/products/risk-monitoring/alerts) to get notified for specific security events — new vulnerabilities, dark web exposures, M365 and Google Workspace activity.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## Summary

- Fills the empty `products/risk-monitoring/overview.mdx` stub with a
  complete Risk Monitoring page
- Adds new `products/risk-monitoring/alerts.mdx` page covering Alert Policies
- Wires both pages into the Products nav in `docs.json`

## What's on these pages

**Risk Monitoring overview**
- Requirements (assessment type, agency plan, agent deployment)
- Scan frequency config walkthrough (Weekly / Monthly / Quarterly / Disable)
- Scan Settings button location (assessment header, agency-flag gated)
- FAQ — includes note that a rescan replaces existing data, not a snapshot

**Alerts**
- Explains agency-level policy scope (not per-assessment)
- Two-step Add Policy flow (Configure Alert Policy → Configure Alert Delivery)
- Full table of all 35 alert categories across Internal, Dark Web, M365, GWS
- Delivery config (user selection by checkbox; SMS not surfaced)
- FAQ (6 questions including webhooks cross-link)

## Review checklist
- [ ] Both pages render correctly in Mintlify preview
- [ ] AccordionGroup / Accordion components render in FAQ sections
- [ ] Nav links in docs.json resolve (Risk Monitoring group appears under Products)
- [ ] Cross-links between overview ↔ alerts pages work
- [ ] Confirm alert category list matches what's currently live in the portal
- [ ] Confirm Scan Settings button label and location are accurate
